### PR TITLE
Adding missing obligation to Apache-2.0 and fix syntax errors in yaml files

### DIFF
--- a/src/AGPL-3.0.yaml
+++ b/src/AGPL-3.0.yaml
@@ -27,18 +27,18 @@
     use_cases: [MB, MS]
     compliance_notes: Strong copyleft or reciprocal, project-based license meaning that derivative works must also be under AGPL-3.0. For more information about AGPL-3.0 compliance and this condition in particular (which is the same as for GPL-3.0), see the references provided or consult with your open source legal counsel.
     seeAlso: 
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-650009[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-650009[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]"
 
   - type: condition
     description: Provide corresponding source code
     use_cases: [UB, MB]
     compliance_notes: Corresponding Source = all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. Options for providing source = with binary, written offer, or via a network server. See section 6 for more details. For more information about AGPL-3.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso: 
-    - https://www.gnu.org/licenses/gpl-faq.html#AGPLv3CorrespondingSource[FSF FAQ: AGPLv3 corresponding source]
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-740009.3[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]
-    - https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]
+    - "https://www.gnu.org/licenses/gpl-faq.html#AGPLv3CorrespondingSource[FSF FAQ: AGPLv3 corresponding source]"
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-740009.3[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]"
 
   - type: condition
     description: No additional restrictions
@@ -58,13 +58,13 @@
     description: Provide information necessary to install modified versions on 'User Products'
     compliance_notes: If convey object code in, with, or specificially for use in a User Product and the right of possession for the User Product is tranferred as part of the conveyance, then the corresponding source code must include Installation Information (methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source) (see section 6 for more details)
     seeAlso:
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-830009.9
-    - https://www.gnu.org/licenses/gpl-faq.en.html#InstInfo 
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-830009.9"
+    - "https://www.gnu.org/licenses/gpl-faq.en.html#InstInfo"
   
   - type: other
     description: Provide corresponding source code for modified versions to users interacting with the program remotely through a computer network (see section 13 for more details). For more information about AGPL-3.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso:
-    - https://www.gnu.org/licenses/gpl-faq.html#AGPLv3InteractingRemotely[FSF FAQ: AGPLv3 interacting remotely]
-    - https://www.gnu.org/licenses/gpl-faq.html#AGPLv3ServerAsUser[FSF FAQ: AGPLv3 server as user]
+    - "https://www.gnu.org/licenses/gpl-faq.html#AGPLv3InteractingRemotely[FSF FAQ: AGPLv3 interacting remotely]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#AGPLv3ServerAsUser[FSF FAQ: AGPLv3 server as user]"
     
  

--- a/src/Apache-2.0.yaml
+++ b/src/Apache-2.0.yaml
@@ -20,9 +20,9 @@
     compliance_notes: Copyright notices and other notices do not have to be reproduced for binary distribution
 
   - type: condition
-    description: Forward notice with the distribution
+    description: Include NOTICE file with distribution
     use_cases: [UB, MB]
-    compliance_notes: 
+    compliance_notes: If a NOTICE is present, include it in any distribution of the work or derivative works (to the extent the NOTICE file appiles to the derivatives)
 
   - type: termination
     description: Any patent claims accusing the work by a licensee results in termination of all patent licenses to the licensee.

--- a/src/Apache-2.0.yaml
+++ b/src/Apache-2.0.yaml
@@ -19,5 +19,10 @@
     use_cases: [US, MS]
     compliance_notes: Copyright notices and other notices do not have to be reproduced for binary distribution
 
+  - type: condition
+    description: Forward notice with the distribution
+    use_cases: [UB, MB]
+    compliance_notes: 
+
   - type: termination
     description: Any patent claims accusing the work by a licensee results in termination of all patent licenses to the licensee.

--- a/src/GPL-2.0.yaml
+++ b/src/GPL-2.0.yaml
@@ -27,18 +27,18 @@
     use_cases: [MB, MS]
     compliance_notes: Strong copyleft or reciprocal, project-based license meaning that derivative works must also be under GPL-2.0. For more information about GPL-2.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso: 
-    - https://copyleft.org/guide/comprehensive-gpl-guidech6.html#x9-410005[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.html#TheGPLSaysModifiedVersions[FSF FAQ: GPL says modified versions]
-    - https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech6.html#x9-410005[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#TheGPLSaysModifiedVersions[FSF FAQ: GPL says modified versions]"
+    - "https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]"
 
   - type: condition
     description: Provide corresponding source code
     use_cases: [UB, MB]
     compliance_notes: Corresponding Source = all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. Options for providing source = with binary, written offer (see section 3 for more details). For more information about GPL-2.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso: 
-    - https://copyleft.org/guide/comprehensive-gpl-guidech6.html#x9-410005[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]
-    - https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech6.html#x9-410005[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]"
 
   - type: condition
     description: No additional restrictions
@@ -51,5 +51,5 @@
   - type: license_versions
     description: Allows use of covered code under the terms of same version or any later version of the license or that version only, as specified. If no license version is specified, then you may use any version ever published by the FSF.
     seeAlso:
-    - https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake] 
+    - "https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]"
 

--- a/src/GPL-3.0.yaml
+++ b/src/GPL-3.0.yaml
@@ -27,17 +27,17 @@
     use_cases: [MB, MS]
     compliance_notes: Strong copyleft or reciprocal, project-based license meaning that derivative works must also be under GPL-3.0. For more information about GPL-3.0 compliance and this condition in particular, see the references provided or consult with your open source legal counsel.
     seeAlso: 
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-650009[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-650009[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.en.html#MereAggregation[FSF FAQ: mere aggregation]"
 
   - type: condition
     description: Provide corresponding source code
     use_cases: [UB, MB]
     compliance_notes: Corresponding Source = all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. Options for providing source = with binary, written offer, or via a network server (see section 6 for more details). For more information about GPL-3.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso: 
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-740009.3[Copyleft Guide]
-    - https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]
-    - https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-740009.3[Copyleft Guide]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#SystemLibraryException[FSF FAQ: System library exception]"
+    - "https://www.gnu.org/licenses/gpl-faq.html#MustSourceBuildToMatchExactHashOfBinary[FSF FAQ: source code match binary]"
 
   - type: condition
     description: May not prohibit circumvention of technological measures that prevent users from exercising rights under the license (see section 3 for more details)
@@ -64,8 +64,8 @@
     description: Provide information necessary to install modified versions on 'User Products'
     compliance_notes: If convey object code in, with, or specificially for use in a User Product and the right of possession for the User Product is tranferred as part of the conveyance, then the corresponding source code must include Installation Information (methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source) (see section 6 for more details)
     seeAlso:
-    - https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-830009.9
-    - https://www.gnu.org/licenses/gpl-faq.en.html#InstInfo  
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech10.html#x13-830009.9"
+    - "https://www.gnu.org/licenses/gpl-faq.en.html#InstInfo"
 
   - type: other
     description: If software is combined with software under AGPL-3.0, AGPL-3.0 applies to combined work and this license continues to the covered work originally under GPL-3.0 (see section 13 for more details).
@@ -73,4 +73,4 @@
   - type: license_versions
     description: Allows use of covered code under the terms of same version or any later version of the license or that version only, as specified. If no license version is specificed, then you may use any version ever published by the FSF.
     seeAlso:
-    - https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake] 
+    - "https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]"

--- a/src/LGPL-2.0.yaml
+++ b/src/LGPL-2.0.yaml
@@ -44,11 +44,11 @@
     description: Allows dynamic linking of code with “a work that uses the Library” under a different license, under certain conditions.
     compliance_notes: Terms of the other license must permit reverse engineering and debugging; must provide a copy of the license and prominent notice that the Library is used; must provide source code via one of the options in section 6 of the license. Also must include any data and utility programs needed for reproducing the executable, but this need not include anything that is normally distributed with the major components of the operating system. For more information about LGPL-2.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso:
-    - https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]
-    - www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]
-    - https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]
+    - "https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]"
+    - "www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]"
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]"
 
   - type: license_versions
     description: Allows use of covered code under the terms of same version or any later version of the license or that version only, as specified. If no license version is specificed, then you may use any version ever published by the FSF.
     seeAlso:
-    - https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]
+    - "https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]"

--- a/src/LGPL-2.1.yaml
+++ b/src/LGPL-2.1.yaml
@@ -44,11 +44,11 @@
     description: Allows dynamic linking of code with “a work that uses the Library” under a different license, under certain conditions.
     compliance_notes: Terms of the other license must permit reverse engineering and debugging; must provide a copy of the license and prominent notice that the Library is used; must provide source code via one of the options in section 6 of the license. Also must include any data and utility programs needed for reproducing the executable, but this need not include anything that is normally distributed with the major components of the operating system. For more information about LGPL-2.1 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso:
-    - https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]
-    - www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]
-    - https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]
+    - "https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]"
+    - "www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]"
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]"
 
   - type: license_versions
     description: Allows use of covered code under the terms of same version or any later version of the license or that version only, as specified. If no license version is specificed, then you may use any version ever published by the FSF.
     seeAlso:
-    - https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]
+    - "https://www.gnu.org/licenses/identify-licenses-clearly.html[Stallman: For Clarity's Sake]"

--- a/src/LGPL-3.0.yaml
+++ b/src/LGPL-3.0.yaml
@@ -16,9 +16,9 @@
     description: Allows distribution of combined LGPL-3.0 and other code under under a different license, under certain conditions.
     compliance_notes: Allows use of a "suitable shared library mechanism" (including dynamic linking) to combine the LGPL-3.0 code with non-LGPL-3.0 code, so long as the source code is provided to allow the user to recombine or relink the application with a modified version of the LGPL-3.0 library. This must include installation information as defined in GPL-3.0, if necessary to install and execute a modified version of the combined work (see sections 4d and 4e for more details). For more information about LGPL-3.0 compliance and this condition in particular, see the references provided or consult your open source legal counsel.
     seeAlso:
-    - https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]
-    - www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]
-    - https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]
+    - "https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic[FSF FAQ: Static v. dynamic]"
+    - "www.softwarefreedom.org/resources/2014/SFLC-Guide_to_GPL_Compliance_2d_ed.html#lgpl[SFLC Compliance Guide]"
+    - "https://copyleft.org/guide/comprehensive-gpl-guidech11.html#x14-9600010[Copyleft Guide]"
     
   - type: other
     description: If you create a combined library combining parts of the library (modified or not) with functions that are not based on the library, then you must accompany the combined library with a copy of the same work based on the library uncombined; give prominent notice that the library is used and explain where to find the accompanying uncomibed form of the work (see section 5 for more details)

--- a/src/TCL.yaml
+++ b/src/TCL.yaml
@@ -4,12 +4,12 @@
   licenseId: TCL
   notes:
   terms:
-  - type:
+  - type: condition
     description: Provide copy of license
     use_cases: [UB, MB, US, MS]
     compliance_notes:
     
-  - type:
+  - type: condition
     description: Retain copyright notices
     use_cases: [UB, MB, US, MS]
     compliance_notes:

--- a/src/zlib.yaml
+++ b/src/zlib.yaml
@@ -4,12 +4,12 @@
   licenseId: zlib
   notes:
   terms:
-  - type:
+  - type: condition
     description: Provide copy of license
     use_cases: [US, MS]
     compliance_notes: Retain copyright and license in any source distribution. However, you might consider the need to identify the presence of software under zlib for other reasons, especially if you have an agreement that wraps around this code/license.
         
-  - type:
+  - type: condition
     description: notice of modifications
     use_cases: [MB, MS]
     compliance_notes: Modified verions must be "plainly marked as such" and not misrepresented as the original software


### PR DESCRIPTION
I have:
- added missing types in `TCL` and `zlib`
- add qoutes to some necessary places (strings containing a colon followed by a space were interpreted as key-value pair)
- added missing "forward Notice" clause to `Apache-2.0`

(I might maybe not be able to sign the CLA)